### PR TITLE
DVOP-1939 tidy notifications

### DIFF
--- a/source/webhook-trigger.py
+++ b/source/webhook-trigger.py
@@ -115,11 +115,14 @@ def verify_environment(variables):
             sys.exit(1)
 
 
-if sys.version_info < MIN_PYTHON:
-    build_exception_message = "Found Python " + str(sys.version_info) + " but need Python %s.%s or later." % MIN_PYTHON
-    send_slack_error_message(build_exception_message, None)
-    sys.exit(build_exception_message)
+def check_python_version(minimum_python_version):
+    if sys.version_info < minimum_python_version:
+        message = "Found Python " + str(sys.version_info) + " but need Python %s.%s or later." % minimum_python_version
+        exception_message(message, None)
+        sys.exit(message)
+    return 0
 
 
+check_python_version(MIN_PYTHON)
 logging.basicConfig()
 logging.getLogger().setLevel(logging.INFO)

--- a/source/webhook-trigger.py
+++ b/source/webhook-trigger.py
@@ -116,10 +116,9 @@ def verify_environment(variables):
 
 
 if sys.version_info < MIN_PYTHON:
-    error_message = "Found Python " + str(sys.version_info) + " but Python %s.%s or later is required. " \
-                                                              "Unable to find towel. Panicking.\n" % MIN_PYTHON
-    send_slack_error_message(error_message, None)
-    sys.exit(error_message)
+    build_exception_message = "Found Python " + str(sys.version_info) + " but need Python %s.%s or later." % MIN_PYTHON
+    send_slack_error_message(build_exception_message, None)
+    sys.exit(build_exception_message)
 
 
 logging.basicConfig()


### PR DESCRIPTION
make the python version check more concise.
rename `error_message` to `build_exception_message` in the python version check so that it is more descriptive.